### PR TITLE
Being able to use special characters in field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ use MrShan0\PHPFirestore\Fields\FirestoreObject;
 use MrShan0\PHPFirestore\Fields\FirestoreReference;
 use MrShan0\PHPFirestore\Attributes\FirestoreDeleteAttribute;
 
-$collection = "myCollectionName"
+$collection = 'myCollectionName';
 
 $firestoreClient->addDocument($collection, [
     'myBooleanTrue' => true,

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ $document->fillValues([
 ]);
 ```
 
+####  Special characters in the field name
+
+If you want to use special characters in the field name, you have to use backticks.
+
+```php
+$document->fillValues([
+    '`teléfono`' => '1234567890',
+    '`contraseña`' => 'secretPassword',
+]);
+```
+
 #### Inserting/Updating a document
 
 - Update (Merge) or Insert document

--- a/src/FirestoreClient.php
+++ b/src/FirestoreClient.php
@@ -354,6 +354,14 @@ class FirestoreClient
         $body = '';
         $options = array_merge($this->getOptions(), $options);
 
+        if (isset($options['json']['fields'])) {
+            $options['json']['fields'] = array_reduce(
+                array_keys($options['json']['fields']),
+                fn ($result, $k) => $result + [str_replace('`', '', $k) => $options['json']['fields'][$k]],
+                []
+            );
+        }
+
         try {
             $response = $this->getHttpClient()->request($method, $this->constructUrl($path, $parameters), $options);
             $this->setLastResponse($response);


### PR DESCRIPTION
To be able to use special characters in field names, backticks ( **`** ) must be used.
I added a usage example to the README as well.