### PR TITLE
added new addNestedDocuments function

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,95 @@ $document->fillValues([
 ]);
 ```
 
+You could use `addNestedDocuments` if you have multiple nested objects 
+
+
+```php
+
+require 'vendor/autoload.php';
+
+use MrShan0\PHPFirestore\FirestoreClient;
+
+$collection = 'myCollectionName';
+
+$originalData = [
+    'name' => 'My Application',
+    'emails' => [
+        'support' => 'support@example.com',
+        'sales' => 'sales@example.com',
+    ],
+    'website' => 'https://app.example.com',
+    'myObject' => [
+        'nested1' => [
+            'name' => 'My Application',
+            'emails' => [
+                'support' => 'support@example.com',
+                'sales' => 'sales@example.com',
+            ],
+            'nested2' => [
+                'name' => 'My Application',
+                'emails' => [
+                    'support' => 'support@example.com',
+                    'sales' => 'sales@example.com',
+                ],
+                'nested3' => [
+                    'name' => 'My Application',
+                    'emails' => [
+                        'support' => 'support@example.com',
+                        'sales' => 'sales@example.com',
+                    ]
+                ]
+            ]
+        ]
+    ]
+];
+
+$firestoreClient->addNestedDocuments($collection, $originalData);
+```
+This just formats the array before using the `addDocument` function
+
+```php
+
+require 'vendor/autoload.php';
+
+use MrShan0\PHPFirestore\FirestoreClient;
+use MrShan0\PHPFirestore\Fields\FirestoreObject;
+
+$collection = 'myCollectionName';
+
+$originalData = [
+    'name' => 'My Application',
+    'emails' => new FirestoreObject( [
+        'support' => 'support@example.com',
+        'sales' => 'sales@example.com',
+    ]),
+    'website' => 'https://app.example.com',
+    'myObject' => new FirestoreObject([
+        'nested1' => new FirestoreObject([
+            'name' => 'My Application',
+            'emails' => new FirestoreObject([
+                'support' => 'support@example.com',
+                'sales' => 'sales@example.com',
+            ]),
+            'nested2' => new FirestoreObject([
+                'name' => 'My Application',
+                'emails' => new FirestoreObject([
+                    'support' => 'support@example.com',
+                    'sales' => 'sales@example.com',
+                ]),
+                'nested3' => new FirestoreObject([
+                    'name' => 'My Application',
+                    'emails' => new FirestoreObject( [
+                        'support' => 'support@example.com',
+                        'sales' => 'sales@example.com',
+                    ])
+                ])
+            ])
+        ])
+    ])
+];
+```
+
 #### Inserting/Updating a document
 
 - Update (Merge) or Insert document

--- a/src/FirestoreClient.php
+++ b/src/FirestoreClient.php
@@ -15,6 +15,7 @@ use MrShan0\PHPFirestore\Helpers\FirestoreHelper;
  * @method array getBatchDocuments(array $documentsId, array $parameters = [], array $options = [])
  * @method FirestoreDocument addDocument($collection, $payload, $documentId = null, array $parameters = [], array $options = [])
  * @method FirestoreDocument updateDocument($documentPath, $payload, $documentExists = null, array $parameters = [], array $options = [])
+ * @method FirestoreDocument addNestedDocuments($documentPath, $payload, $documentExists = null, array $parameters = [], array $options = [])
  * @method FirestoreDocument setDocument($documentPath, $payload, $documentExists = null, array $parameters = [], array $options = [])
  * @method boolean deleteDocument($document, array $options = [])
  */

--- a/src/FirestoreDatabaseResource.php
+++ b/src/FirestoreDatabaseResource.php
@@ -38,6 +38,8 @@ class FirestoreDatabaseResource
         $slashesCount = substr_count($path, '/');
         $isEvenNumber = $slashesCount % 2 == 0;
 
+
+
         if (($shouldBeOdd && $isEvenNumber) || (!$shouldBeOdd && !$isEvenNumber)) {
             throw new InvalidPathProvided($path);
         }
@@ -175,6 +177,25 @@ class FirestoreDatabaseResource
     }
 
     /**
+     * Insert a document under collection path given, When you want to add an array with nested
+     * it makes the nested arrays a FirestoreObject
+     *
+     *
+     * @param string $documentPath
+     * @param array|FirestoreDocument $payload
+     * @param string|null $documentId
+     * @param array $parameters
+     * @param array $options
+     *
+     * @return \MrShan0\PHPFirestore\FirestoreDocument
+     */
+    public function addNestedDocuments($documentPath, $payload, $documentId = null, array $parameters = [], array $options = []): \MrShan0\PHPFirestore\FirestoreDocument
+    {
+        $payload = FirestoreHelper::normalizedNestedArray($payload);
+        return $this->addDocument($documentPath, $payload, $documentId , $parameters,$options);
+    }
+
+    /**
      * It'll merge document with existing one or insert if it doesn't exist. When you want your update your
      * data and don't want to affect existing parameters, use this.
      *
@@ -206,6 +227,7 @@ class FirestoreDatabaseResource
      */
     public function setDocument($documentPath, $payload, $documentExists = null, array $parameters = [], array $options = [])
     {
+
         $this->validatePath($documentPath);
 
         if ($payload instanceof FirestoreDocument) {

--- a/src/Helpers/FirestoreHelper.php
+++ b/src/Helpers/FirestoreHelper.php
@@ -5,6 +5,7 @@ namespace MrShan0\PHPFirestore\Helpers;
 use MrShan0\PHPFirestore\Attributes\FirestoreDeleteAttribute;
 use MrShan0\PHPFirestore\Fields\FirestoreArray;
 use MrShan0\PHPFirestore\Fields\FirestoreGeoPoint;
+use MrShan0\PHPFirestore\Fields\FirestoreObject;
 use MrShan0\PHPFirestore\Fields\FirestoreReference;
 use MrShan0\PHPFirestore\Fields\FirestoreTimestamp;
 use MrShan0\PHPFirestore\Fields\FirestoreBytes;
@@ -123,5 +124,25 @@ class FirestoreHelper
 
         return $type;
     }
+
+    /**
+     * This will recursively add FirestoreObject to a nested array
+     *
+     * @param  array $value
+     *
+     * @return array
+     */
+    public static function normalizedNestedArray(array $data)
+    {
+        foreach ($data as $key => $value){
+
+            if (is_array($value)) {
+                $data[$key] = new FirestoreObject(self::normalizedNestedArray($value));
+            }
+        }
+
+        return $data;
+    }
+
 
 }


### PR DESCRIPTION

Hello Brent,

While using the `addDocument` function, I noticed that when I sent a nested array, it showed up differently in my Firestore. For example:

```php
require 'vendor/autoload.php';

use MrShan0\PHPFirestore\FirestoreClient;
$collection = 'myCollectionName';

$originalData = [
    'name' => 'My Application',
    'emails' => [
        'support' => 'support@example.com',
        'sales' => 'sales@example.com',
    ]
];

$firestoreClient->addDocuments($collection, $originalData);
```

Firestore retrieved this data as:

```php
[
    'name' => 'My Application',
    'emails' => [
        0 => 'support@example.com',
        1 => 'sales@example.com'
    ]
]
```

After some debugging, I realized that I needed to use the `FirestoreObject` class to achieve the desired result. So, I decided to add a new function called `addNestedDocuments`, which first utilizes the `FirestoreHelper::normalizeNestedArray($payload)` method before proceeding to add the document.

```php
require 'vendor/autoload.php';

use MrShan0\PHPFirestore\FirestoreClient;
$collection = 'myCollectionName';

$originalData = [
    'name' => 'My Application',
    'emails' => [
        'support' => 'support@example.com',
        'sales' => 'sales@example.com',
    ]
];

$firestoreClient->addNestedDocuments($collection, $originalData);
```

Great package (saved me from gRPC)! I noticed a few items on the TODO list that I might be able to help with as well.

Best regards,  
Adams

